### PR TITLE
Improve trigger in order to use Firestore only

### DIFF
--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -14,13 +14,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+      - id: "auth"
+        uses: "google-github-actions/auth@v1"
         with:
-          version: "290.0.1"
-          project_id: "coreofscience-dev"
-          service_account_key: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
-          export_default_credentials: true
+          credentials_json: "${{ secrets.GCLOUD_SERVICE_ACCOUNT }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
 
       - name: Deploy function
         run: |

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -34,7 +34,8 @@ jobs:
           gcloud functions deploy create_tree_v2 \
             --project coreofscience-dev \
             --trigger-event "providers/cloud.firestore/eventTypes/document.create" \
-            --trigger-resource "projects/coreofscience-dev/databases/(default)/documents/trees/{treeId}"
+            --trigger-resource "projects/coreofscience-dev/databases/(default)/documents/trees/{treeId}" \
             --set-env-vars STORAGEBUCKET="coreofscience-dev.appspot.com",DATABASEURL="https://coreofscience-dev.firebaseio.com" \
             --source ./create-tree-v2 \
-            --runtime python38 \
+            --entry-point create_tree_v2 \
+            --runtime python310

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -3,7 +3,7 @@ name: Deploy function to dev
 on:
   push:
     branches:
-      - feature-create-tree-v2
+      - feature-create-tree-v2 # On pushing to this branch, this workflow will be dispatched
 
 jobs:
   build-and-deploy:
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: create_tree-v2 # The branch to checkout
+          ref: feature-create-tree-v2 # The branch to checkout for the deploy
           persist-credentials: false
 
       - id: "auth"
@@ -25,9 +25,6 @@ jobs:
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
-
-      - name: "Use gcloud CLI"
-        run: "gcloud info"
 
       - name: Deploy function
         run: |

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -31,8 +31,10 @@ jobs:
 
       - name: Deploy function
         run: |
-          cd create-tree-v2 && gcloud functions deploy create_tree_v2 \
+          gcloud functions deploy create_tree_v2 \
+            --project coreofscience-dev \
             --set-env-vars STORAGEBUCKET="coreofscience-dev.appspot.com",DATABASEURL="https://coreofscience-dev.firebaseio.com" \
             --runtime python310 \
+            --source ./create-tree-v2 \
             --trigger-event "providers/cloud.firestore/eventTypes/document.create" \
             --trigger-resource "projects/coreofscience-dev/databases/(default)/documents/trees/{treeId}"

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -33,8 +33,8 @@ jobs:
         run: |
           gcloud functions deploy create_tree_v2 \
             --project coreofscience-dev \
-            --set-env-vars STORAGEBUCKET="coreofscience-dev.appspot.com",DATABASEURL="https://coreofscience-dev.firebaseio.com" \
-            --runtime python310 \
-            --source ./create-tree-v2 \
             --trigger-event "providers/cloud.firestore/eventTypes/document.create" \
             --trigger-resource "projects/coreofscience-dev/databases/(default)/documents/trees/{treeId}"
+            --set-env-vars STORAGEBUCKET="coreofscience-dev.appspot.com",DATABASEURL="https://coreofscience-dev.firebaseio.com" \
+            --source ./create-tree-v2 \
+            --runtime python38 \

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -3,7 +3,7 @@ name: Deploy function to dev
 on:
   push:
     branches:
-      - create_tree-v2
+      - feature-create-tree-v2
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -1,0 +1,32 @@
+name: Deploy function to dev
+
+on:
+  push:
+    branches:
+      - create_tree-v2
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup gcloud
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: "290.0.1"
+          project_id: "coreofscience-dev"
+          service_account_key: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
+          export_default_credentials: true
+
+      - name: Deploy function
+        run: |
+          gcloud functions deploy create-tree-v2 \
+            --entry-point ./create-tree-v2 \
+            --runtime python311 \
+            --trigger-event "providers/cloud.firestore/eventTypes/document.create" \
+            --trigger-resource "projects/coreofscience-dev/databases/(default)/documents/trees/{treeId}"
+            --set-env-vars STORAGEBUCKET="coreofscience-dev.appspot.com",DATABASEURL="https://coreofscience-dev.firebaseio.com" \

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -24,8 +24,7 @@ jobs:
 
       - name: Deploy function
         run: |
-          gcloud functions deploy create_tree_v2 \
-            --entry-point ./create-tree-v2 \
+          cd create-tree-v2 && gcloud functions deploy create_tree_v2 \
             --runtime python311 \
             --trigger-event "providers/cloud.firestore/eventTypes/document.create" \
             --trigger-resource "projects/coreofscience-dev/databases/(default)/documents/trees/{treeId}"

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -8,10 +8,14 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: create_tree-v2 # The branch to checkout
           persist-credentials: false
 
       - id: "auth"
@@ -21,6 +25,9 @@ jobs:
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: "Use gcloud CLI"
+        run: "gcloud info"
 
       - name: Deploy function
         run: |

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Deploy function
         run: |
           cd create-tree-v2 && gcloud functions deploy create_tree_v2 \
-            --runtime python311 \
+            --set-env-vars STORAGEBUCKET="coreofscience-dev.appspot.com",DATABASEURL="https://coreofscience-dev.firebaseio.com" \
+            --runtime python310 \
             --trigger-event "providers/cloud.firestore/eventTypes/document.create" \
             --trigger-resource "projects/coreofscience-dev/databases/(default)/documents/trees/{treeId}"
-            --set-env-vars STORAGEBUCKET="coreofscience-dev.appspot.com",DATABASEURL="https://coreofscience-dev.firebaseio.com" \

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -15,7 +15,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup gcloud
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v1
         with:
           version: "290.0.1"
           project_id: "coreofscience-dev"

--- a/.github/workflows/deploy-dev-v2.yml
+++ b/.github/workflows/deploy-dev-v2.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Deploy function
         run: |
-          gcloud functions deploy create-tree-v2 \
+          gcloud functions deploy create_tree_v2 \
             --entry-point ./create-tree-v2 \
             --runtime python311 \
             --trigger-event "providers/cloud.firestore/eventTypes/document.create" \

--- a/.github/workflows/deploy-prod-v2.yml
+++ b/.github/workflows/deploy-prod-v2.yml
@@ -2,8 +2,8 @@ name: Deploy function to dev
 
 on:
   push:
-    branches:
-      - main # On pushing to this branch, this workflow will be dispatched
+    tags:
+      - v*
 
 jobs:
   build-and-deploy:
@@ -29,10 +29,10 @@ jobs:
       - name: Deploy function
         run: |
           gcloud functions deploy create_tree_v2 \
-            --project coreofscience-dev \
+            --project coreofscience \
             --trigger-event "providers/cloud.firestore/eventTypes/document.create" \
-            --trigger-resource "projects/coreofscience-dev/databases/(default)/documents/trees/{treeId}" \
-            --set-env-vars STORAGEBUCKET="coreofscience-dev.appspot.com",DATABASEURL="https://coreofscience-dev.firebaseio.com" \
+            --trigger-resource "projects/coreofscience/databases/(default)/documents/trees/{treeId}" \
+            --set-env-vars STORAGEBUCKET="coreofscience.appspot.com",DATABASEURL="https://coreofscience.firebaseio.com" \
             --source ./create-tree-v2 \
             --entry-point create_tree_v2 \
             --runtime python310

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -82,7 +82,6 @@ def get_int_utcnow() -> int:
 
 def create_tree_v2(event, context):
     """Handles new created documents in firestore with path `trees/{treeId}`"""
-    # document_reference.update({"_gcloudLogsSessionUrl": logging_client})
     tree_id = context.resource.split("/").pop()
 
     logging.info(f"Handling new created tree {event} {context} {tree_id}")

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -85,8 +85,7 @@ def create_tree_v2(event, context):
     # document_reference.update({"_gcloudLogsSessionUrl": logging_client})
     tree_id = context.resource.split("/").pop()
 
-    extra = {"tree_id": tree_id, "context": context}
-    logging.info(f"Handling new created tree", extra=extra)
+    logging.info(f"Handling new created tree {event} {context} {tree_id}")
 
     client = firestore.client()
     document_reference = client.collection("trees").document(tree_id)

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -61,7 +61,7 @@ def get_contents(document_data: Dict[str, Any]) -> Dict[str, str]:
         f'isi-files/{name["stringValue"]}'
         for name in document_data["files"]["arrayValue"]["values"]
     ]
-    logging.info("Reading source files", extra={names})
+    logging.info("Reading source files", extra={"names": names})
     blobs = [BUCKET.get_blob(name) for name in names]
 
     size = 0
@@ -82,8 +82,11 @@ def get_int_utcnow() -> int:
 
 def create_tree_v2(event, context):
     """Handles new created documents in firestore with path `trees/{treeId}`"""
+    # document_reference.update({"_gcloudLogsSessionUrl": logging_client})
 
-    logging.info(f"Handling new created tree", extra={tree_id})
+    logging.info(
+        f"Handling new created tree", extra={"tree_id": tree_id, "context": context}
+    )
     client = firestore.client()
     tree_id = context.resource.split("/").pop()
     document_reference = client.collection("trees").document(tree_id)

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -83,12 +83,12 @@ def get_int_utcnow() -> int:
 def create_tree_v2(event, context):
     """Handles new created documents in firestore with path `trees/{treeId}`"""
     # document_reference.update({"_gcloudLogsSessionUrl": logging_client})
-
-    logging.info(
-        f"Handling new created tree", extra={"tree_id": tree_id, "context": context}
-    )
-    client = firestore.client()
     tree_id = context.resource.split("/").pop()
+
+    extra = {"tree_id": tree_id, "context": context}
+    logging.info(f"Handling new created tree", extra=extra)
+
+    client = firestore.client()
     document_reference = client.collection("trees").document(tree_id)
     document_reference.update({"startedDate": get_int_utcnow()})
 

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List
 from dataclasses import asdict
 
 import google.cloud.logging
-from firebase_admin import initialize_app
 from google.cloud import storage, firestore
 from igraph import Graph
 from sap import Sap, giant
@@ -24,13 +23,6 @@ DATABASE_URL = os.getenv("DATABASEURL")
 BUCKET = storage_client.get_bucket(BUCKET_URL)
 
 MAX_SIZE = 10  # MB
-
-
-initialize_app(
-    options={
-        "databaseURL": DATABASE_URL,
-    }
-)
 
 
 def tree_from_strings(strings: List[str]) -> Graph:

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -72,14 +72,10 @@ def get_int_utcnow() -> int:
 
 
 def create_tree_v2(event, context):
-    logging.basicConfig("%(asctime)s %(tree_id)s %(message)s")
-    logger = logging.getLogger("tree-collection-create-logger")
-
     client = firestore.Client()
 
     tree_id = context.resource.split("/").pop()
-    logger_extra = {"treeId": tree_id}
-    logger.info("Handling new created tree", extra=logger_extra)
+    logging.info("Handling new created tree ({tree_id})")
 
     document_reference = client.collection("trees").document(tree_id)
 
@@ -89,7 +85,7 @@ def create_tree_v2(event, context):
     document_reference.set(document_data)
 
     try:
-        logger.info("Tree process started", extra=logger_extra)
+        logging.info("Tree process started ({tree_id})")
 
         contents = get_contents(document_data)
         tos = tree_from_strings(list(contents.values()))
@@ -98,9 +94,9 @@ def create_tree_v2(event, context):
             {"result": result, "errorMessage": None, "fileNames": list(contents.keys())}
         )
 
-        logger.info("Tree process finished", extra=logger_extra)
+        logging.info("Tree process finished ({tree_id})")
     except Exception as error:
-        logger.exception("Tree process failed", extra=logger_extra)
+        logging.exception("Tree process failed ({tree_id})")
         document_data.update(
             {"result": None, "errorMessage": str(error), "fileNames": None}
         )

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -1,0 +1,122 @@
+import base64
+import logging
+import os
+from datetime import datetime
+from io import StringIO
+from typing import Any, Dict, List
+from dataclasses import asdict
+
+import google.cloud.logging
+from firebase_admin import initialize_app
+from google.cloud import storage, firestore
+from igraph import Graph
+from sap import Sap, giant
+from wostools import Collection
+
+
+storage_client = storage.Client()
+logging_client = google.cloud.logging.Client()
+logging_client.get_default_handler()
+logging_client.setup_logging()
+
+BUCKET_URL = os.getenv("STORAGEBUCKET")
+DATABASE_URL = os.getenv("DATABASEURL")
+BUCKET = storage_client.get_bucket(BUCKET_URL)
+
+MAX_SIZE = 10  # MB
+
+
+logging.basicConfig("%(asctime)s %(tree_id)s %(message)s")
+logger = logging.getLogger("tree-collection-create-logger")
+
+initialize_app(
+    options={
+        "databaseURL": DATABASE_URL,
+    }
+)
+
+client = firestore.Client()
+
+
+def tree_from_strings(strings: List[str]) -> Graph:
+    """Creates a ToS tree from a list of strings."""
+    sap = Sap()
+    graph = giant(Collection(*[StringIO(text) for text in strings]))
+    return sap.tree(graph)
+
+
+def convert_tos_to_json(tree: Graph) -> Dict[str, List[Dict]]:
+    """
+    Converts a ToS graph in the default format to be processed by the frontend.
+    """
+    output = {}
+    sections = ["root", "trunk", "leaf"]
+    for section in sections:
+        vertices = tree.vs.select(**{f"{section}_gt": 0})
+        data = sorted(
+            [vertex.attributes() for vertex in vertices],
+            key=lambda article: article.get(section, 0),
+            reverse=True,
+        )
+        output[section] = data
+
+    return output
+
+
+def get_contents(delta: Dict[str, Any]) -> Dict[str, str]:
+    """Get the contents for the files in order to create the graph."""
+    names = [f"isi-files/{name}" for name in delta["files"].values()]
+    logging.info(f"Reading source files {names}")
+    blobs = [BUCKET.get_blob(name) for name in names]
+
+    size = 0
+    output = {}
+    for blob in blobs:
+        if blob is not None:
+            size += blob.size
+            if (size / 1e6) > MAX_SIZE:
+                break
+            output[blob.name] = blob.download_as_text()
+    return output
+
+
+def get_int_utcnow() -> int:
+    return int(datetime.utcnow().timestamp())
+
+
+def create_tree_v2(event, context):
+    tree_id = context.resource.split("/").pop()
+    logger_extra = {"treeId": tree_id}
+    logger.info("Handling new created tree", extra=logger_extra)
+
+    document_reference = client.collection("trees").document(tree_id)
+
+    document_data = event["value"]["fields"]
+
+    document_data.update({"startedDate": get_int_utcnow()})
+    document_reference.set(document_data)
+
+    try:
+        logger.info("Tree process started", extra=logger_extra)
+
+        contents = get_contents(asdict(event))
+        tos = tree_from_strings(list(contents.values()))
+        result = convert_tos_to_json(tos)
+        document_data.update(
+            {"result": result, "errorMessage": None, "fileNames": list(contents.keys())}
+        )
+
+        logger.info("Tree process finished", extra=logger_extra)
+    except Exception as error:
+        logger.exception("Tree process failed", extra=logger_extra)
+        document_data.update(
+            {"result": None, "errorMessage": str(error), "fileNames": None}
+        )
+
+    document_data.update(
+        {
+            "version": "2",
+            "finishedDate": get_int_utcnow(),
+        }
+    )
+    document_reference.set(document_data)

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -61,7 +61,7 @@ def get_contents(document_data: Dict[str, Any]) -> Dict[str, str]:
         f'isi-files/{name["stringValue"]}'
         for name in document_data["files"]["arrayValue"]["values"]
     ]
-    logging.info(f"Reading source files {names}")
+    logging.info("Reading source files", extra={names})
     blobs = [BUCKET.get_blob(name) for name in names]
 
     size = 0
@@ -83,14 +83,14 @@ def get_int_utcnow() -> int:
 def create_tree_v2(event, context):
     """Handles new created documents in firestore with path `trees/{treeId}`"""
 
-    logging.info("Handling new created tree ({tree_id})")
+    logging.info(f"Handling new created tree", extra={tree_id})
     client = firestore.client()
     tree_id = context.resource.split("/").pop()
     document_reference = client.collection("trees").document(tree_id)
     document_reference.update({"startedDate": get_int_utcnow()})
 
     try:
-        logging.info("Tree process started ({tree_id})")
+        logging.info("Tree process started")
         contents = get_contents(event["value"]["fields"])
         tos = tree_from_strings(list(contents.values()))
         result = convert_tos_to_json(tos)
@@ -102,9 +102,9 @@ def create_tree_v2(event, context):
                 "finishedDate": get_int_utcnow(),
             }
         )
-        logging.info("Tree process finished ({tree_id})")
+        logging.info("Tree process finished")
     except Exception as error:
-        logging.exception("Tree process failed ({tree_id})")
+        logging.exception("Tree process failed")
         document_reference.update(
             {
                 "version": "2",

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, List
 from dataclasses import asdict
 
 import google.cloud.logging
-from google.cloud import storage, firestore
+from firebase_admin import firestore, initialize_app
+from google.cloud import storage
 from igraph import Graph
 from sap import Sap, giant
 from wostools import Collection
@@ -23,6 +24,12 @@ DATABASE_URL = os.getenv("DATABASEURL")
 BUCKET = storage_client.get_bucket(BUCKET_URL)
 
 MAX_SIZE = 10  # MB
+
+initialize_app(
+    options={
+        "databaseURL": DATABASE_URL,
+    }
+)
 
 
 def tree_from_strings(strings: List[str]) -> Graph:
@@ -72,7 +79,7 @@ def get_int_utcnow() -> int:
 
 
 def create_tree_v2(event, context):
-    client = firestore.Client()
+    client = firestore.client()
 
     tree_id = context.resource.split("/").pop()
     logging.info("Handling new created tree ({tree_id})")

--- a/create-tree-v2/main.py
+++ b/create-tree-v2/main.py
@@ -1,10 +1,8 @@
-import base64
 import logging
 import os
 from datetime import datetime
 from io import StringIO
 from typing import Any, Dict, List
-from dataclasses import asdict
 
 import google.cloud.logging
 from firebase_admin import firestore, initialize_app

--- a/create-tree-v2/requirements.txt
+++ b/create-tree-v2/requirements.txt
@@ -2,4 +2,3 @@ python-sap==2.0.0
 firebase-admin==4.4.0
 google-cloud-storage==1.31.2
 google-cloud-logging==1.15.1
-dacite==1.7.0

--- a/create-tree-v2/requirements.txt
+++ b/create-tree-v2/requirements.txt
@@ -1,0 +1,5 @@
+python-sap==2.0.0
+firebase-admin==4.4.0
+google-cloud-storage==1.31.2
+google-cloud-logging==1.15.1
+dacite==1.7.0


### PR DESCRIPTION
Create a new version of the trigger in order to use Firestore only, **which will help decreasing the complexity of the app**.

The goal is to dispatch the trigger when a new document is created including a `createdDate` and `files` on it (the last will targets one of the files already saved in the Firebase Storage), the rest of the data will be generated by the trigger internally, something like this:

https://user-images.githubusercontent.com/104392220/214776826-4983e251-4761-46ee-bd40-beaa8b8ae123.mov

